### PR TITLE
Update SLEquipmentConfigurationMessage.js

### DIFF
--- a/messages/SLEquipmentConfigurationMessage.js
+++ b/messages/SLEquipmentConfigurationMessage.js
@@ -100,7 +100,7 @@ exports.SLEquipmentConfigurationMessage = class SLEquipmentConfigurationMessage 
 
     let numPumps = 0;
     for (var i = 0; i < this.flowDataArray.length; i += 45) {
-      if (this.flowDataArray[i + 2] !== 0) {
+      if (this.flowDataArray[i] !== 0) {
         numPumps++;
       }
     }


### PR DESCRIPTION
Modified getNumPumps() to use byte0 of each 45 byte pump record in flowDataArray rather than byte2.  Byte0 tracks with pump type configuration in SLConfig app.  Reports 0 if no pump configured for the record, 0x6 if an IntelliFlo VF, 0x40 for IntelliFlo VSF and 0x80 for IntelliFlo VS pump.  These values are not the same to those returned in pump type in the GetPumpStatus msg but do report the correct pump model as GetPumpStatus, just with different values.  Byte 2 appears to report a value of 2 for all valid pump slots (varies across controller model) but does not appear to track to whether a pump is present or not in a given valid slot.

Resolves #58.